### PR TITLE
service-account: add Swagger UI and update readme

### DIFF
--- a/services/service-account/README.md
+++ b/services/service-account/README.md
@@ -2,120 +2,157 @@
 
 Django microservice responsible for account commands (create, update, freeze, delete, transaction start, exchange start).
 
-This service uses:
-- PostgreSQL for persistence
-- RabbitMQ for publishing events to other services
+**Stack:** Python 3.12 · Django 5.0.1 · Django REST Framework · PostgreSQL · RabbitMQ · PyJWT
+
+---
 
 ## Architecture
 
-- `accounts/views.py`: HTTP handlers
-- `accounts/serializers.py`: request validation + response shaping
-- `accounts/services.py`: business logic
-- `accounts/publishers.py`: RabbitMQ publishing
-- `accounts/models.py`: ORM models
+| File | Responsibility |
+|---|---|
+| `accounts/views.py` | HTTP handlers, JWT extraction |
+| `accounts/serializers.py` | Request validation + response shaping |
+| `accounts/services.py` | Business logic, duplicate guard |
+| `accounts/publishers.py` | RabbitMQ event publishing |
+| `accounts/models.py` | ORM models (`Account`, `AccountDetail`, `AccountType`, `DeletedAccount`) |
+| `account_service/urls.py` | Root routing — mounts endpoints under `/v1/accounts/` |
+| `account_service/settings.py` | Django settings, JWT config, Swagger config |
 
-Root routing is defined in `account_service/urls.py` and mounts all endpoints under `/accounts/`.
+---
 
 ## Endpoints
 
-All endpoints are rooted at `/accounts/`.
+All endpoints are rooted at `/v1/accounts/`.
 
-| Method | Endpoint                         | Purpose                            |
-|--------|----------------------------------|------------------------------------|
-| POST   | `/accounts/`                     | Create account                     |
-| PUT    | `/accounts/{guid}/`              | Rename / change account type       |
-| PATCH  | `/accounts/{guid}/`              | Freeze/unfreeze                    |
-| DELETE | `/accounts/{guid}/`              | Soft delete                        |
-| POST   | `/accounts/{guid}/transactions/` | Initiate transfer/withdraw/deposit |
-| POST   | `/accounts/{guid}/exchanges/`    | Initiate currency exchange         |
+| Method | Endpoint | Contract | Auth |
+|---|---|---|---|
+| POST | `/v1/accounts/` | 1 – Create account | JWT required |
+| PATCH | `/v1/accounts/{guid}/` | 2 – Freeze / unfreeze | None |
+| PUT | `/v1/accounts/{guid}/` | 3 – Rename / change type | None |
+| DELETE | `/v1/accounts/{guid}/` | 4 – Soft delete | None |
+| POST | `/v1/accounts/{guid}/transactions/` | 5 – Initiate transaction | None |
+| POST | `/v1/accounts/{guid}/exchanges/` | 6 – Initiate currency exchange | None |
+
+### Swagger UI / OpenAPI
+
+A live Swagger UI is served at `/api/docs/` and the raw OpenAPI 3.0 schema at `/api/schema/`.
+
+---
+
+## Authentication
+
+`POST /v1/accounts/` reads `owner_id` exclusively from a JWT. The token is expected either as:
+- `Authorization: Bearer <token>` header, or
+- `auth_token` cookie (set by `service-auth`)
+
+The JWT must be signed with HS256 using the secret in `JWT_SECRET_KEY`. The `nameid` claim is used as `owner_id`.
+
+---
 
 ## Example request bodies
 
-Create account:
-
+**Create account** (`POST /v1/accounts/`)
 ```json
 {
-   "owner_id": "user-123",
-   "name": "My Savings",
-   "type": "savings"
+  "name": "My Savings",
+  "type": "savings"
 }
 ```
 
-Freeze/unfreeze:
-
+**Freeze / unfreeze** (`PATCH /v1/accounts/{guid}/`)
 ```json
 {
-   "freeze": true
+  "freeze": true
 }
 ```
 
-Rename/change type:
-
+**Rename / change type** (`PUT /v1/accounts/{guid}/`)
 ```json
 {
-   "name": "Daily Account",
-   "type": "checking"
+  "name": "Daily Account",
+  "type": "checking"
 }
 ```
 
-Transaction:
-
+**Transaction** (`POST /v1/accounts/{guid}/transactions/`)
 ```json
 {
-   "amount": "500",
-   "transactionType": "DEPOSIT",
-   "messageId": "550e8400-e29b-41d4-a716-446655440000"
+  "amount": "500",
+  "transactionType": "DEPOSIT",
+  "messageId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+> `transactionType` must be one of: `DEPOSIT`, `WITHDRAW`, `TRANSFER`.  
+> `receiverAccountGuid` is required when `transactionType` is `TRANSFER`.
+
+**Exchange** (`POST /v1/accounts/{guid}/exchanges/`)
+```json
+{
+  "amount": "100",
+  "currency": "EUR",
+  "messageId": "40ff6f1a-3b84-43a6-b440-d15918f5bc64"
 }
 ```
 
-Exchange:
-
-```json
-{
-   "amount": "100",
-   "currency": "EUR",
-   "messageId": "40ff6f1a-3b84-43a6-b440-d15918f5bc64"
-}
-```
+---
 
 ## RabbitMQ publishing
 
-The service publishes events to these exchanges:
+| Exchange | Type | Routing key | Published on |
+|---|---|---|---|
+| `account-exchange-events` | fanout | — | Create, Delete |
+| `synchronize-events` | direct | `synchronize-account-queue` | Create, Freeze, Update, Delete |
+| `ai-service-transaction` | fanout | — | Transaction, Exchange |
 
-- `account-exchange-events` (fanout): account create/delete events
-- `synchronize-events` (direct): account state sync events
-- `ai-service-transaction` (fanout): fraud-check requests for transactions/exchanges
+---
 
-Default routing key used for synchronize events:
+## Database model
 
-- `synchronize-account-queue`
+The service uses an **immutable history pattern** — rows are never mutated or hard-deleted:
 
-## Run locally (dev container)
+- Every state change (rename, freeze) creates a new `AccountDetail` row
+- Deletes create a `DeletedAccount` row; the `Account` row is preserved
+- The current state of an account is always the latest `AccountDetail` by timestamp
 
-1. Reopen the folder in dev container
-2. Run migrations
-3. Start server
+**Tables:** `accounts` · `account_types` · `account_details` · `deleted_accounts`
 
-```bash
-python manage.py migrate
-python manage.py runserver 0.0.0.0:8000
-```
-
-RabbitMQ management UI is available at `http://localhost:15672`.
-
-## Database notes
-
-The service uses immutable account history:
-
-- Updates create a new row in `account_details`
-- Deletes create a row in `deleted_accounts`
-- Rows in `accounts` are not hard-deleted
-
-Useful SQL checks:
-
+Useful SQL:
 ```sql
 SELECT * FROM accounts;
 SELECT * FROM account_types;
 SELECT * FROM account_details ORDER BY timestamp DESC;
 SELECT * FROM deleted_accounts ORDER BY timestamp DESC;
 ```
+
+---
+
+## Running locally (dev container)
+
+1. Open the folder in VS Code and select **Reopen in Container**
+2. In the devcontainer terminal:
+
+```bash
+python manage.py migrate
+python manage.py runserver 0.0.0.0:8000
+```
+
+Port `8000` is forwarded automatically. Open:
+- API: `http://localhost:8000/v1/accounts/`
+- Swagger UI: `http://localhost:8000/api/docs/`
+- RabbitMQ UI: `http://localhost:15672`
+
+---
+
+## Environment variables
+
+| Variable | Description |
+|---|---|
+| `POSTGRES_DB` | Database name |
+| `POSTGRES_USER` | Database user |
+| `POSTGRES_PASSWORD` | Database password |
+| `POSTGRES_HOST` | Database host (default: `db`) |
+| `RABBITMQ_HOST` | RabbitMQ host (default: `localhost`) |
+| `RABBITMQ_PORT` | RabbitMQ port (default: `5672`) |
+| `RABBITMQ_USER` | RabbitMQ user (default: `guest`) |
+| `RABBITMQ_PASSWORD` | RabbitMQ password |
+| `JWT_SECRET_KEY` | HS256 secret used to verify `auth_token` JWTs |

--- a/services/service-account/account_service/settings.py
+++ b/services/service-account/account_service/settings.py
@@ -15,6 +15,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "corsheaders",
     "rest_framework",
+    "drf_spectacular",
     "accounts",
 ]
 
@@ -67,6 +68,30 @@ CORS_ALLOWED_ORIGINS = [
     if origin
 ]
 CORS_ALLOW_CREDENTIALS = True
+
+# OpenAPI / Swagger
+SPECTACULAR_SETTINGS = {
+    "TITLE": "HABO Banking – Account Service API",
+    "DESCRIPTION": "Manages bank accounts: create, update, freeze, delete, transactions and currency exchanges.",
+    "VERSION": "1.0.0",
+    "SERVE_INCLUDE_SCHEMA": False,
+    "SECURITY": [{"BearerAuth": []}],
+    "APPEND_COMPONENTS": {
+        "securitySchemes": {
+            "BearerAuth": {
+                "type": "http",
+                "scheme": "bearer",
+                "bearerFormat": "JWT",
+            }
+        }
+    },
+}
+
+REST_FRAMEWORK = {
+    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+    "DEFAULT_AUTHENTICATION_CLASSES": [],
+    "DEFAULT_PERMISSION_CLASSES": [],
+}
 
 # JWT
 JWT_SECRET_KEY = os.getenv("JWT_SECRET_KEY", "")

--- a/services/service-account/account_service/urls.py
+++ b/services/service-account/account_service/urls.py
@@ -4,7 +4,12 @@ Root-level routing that delegates /accounts/ to the accounts app.
 """
 
 from django.urls import include, path  # type: ignore[import-untyped]
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView  # type: ignore[import-untyped]
 
 urlpatterns = [
     path("v1/accounts/", include("accounts.urls")),
+    # OpenAPI schema (raw YAML/JSON)
+    path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
+    # Swagger UI
+    path("api/docs/", SpectacularSwaggerView.as_view(url_name="schema"), name="swagger-ui"),
 ]

--- a/services/service-account/accounts/views.py
+++ b/services/service-account/accounts/views.py
@@ -21,10 +21,9 @@ from accounts.serializers import (
 )
 from accounts.services import DuplicateAccountError
 from django.http import JsonResponse  # type: ignore[import-untyped]
-from django.views.decorators.csrf import csrf_exempt  # type: ignore[import-untyped]
-from django.views.decorators.http import (  # type: ignore[import-untyped]
-    require_http_methods,
-)
+from drf_spectacular.utils import OpenApiResponse, extend_schema  # type: ignore[import-untyped]
+from rest_framework.decorators import api_view  # type: ignore[import-untyped]
+from rest_framework.request import Request  # type: ignore[import-untyped]
 
 logger = logging.getLogger(__name__)
 
@@ -89,9 +88,19 @@ def _get_owner_id_from_jwt(request):
 # /accounts  (POST create)
 
 
-@csrf_exempt
-@require_http_methods(["POST"])
-def account_list(request):
+@extend_schema(
+    summary="Create a new bank account (Contract 1)",
+    request=CreateAccountSerializer,
+    responses={
+        201: AccountResponseSerializer,
+        200: AccountResponseSerializer,
+        400: OpenApiResponse(description="Validation error or invalid JSON"),
+        401: OpenApiResponse(description="Missing or invalid JWT"),
+        409: OpenApiResponse(description="Duplicate account (same owner, name and type)"),
+    },
+)
+@api_view(["POST"])
+def account_list(request: Request):
     """Create a new account (POST)."""
     return _create_account(request)
 
@@ -126,9 +135,36 @@ def _create_account(request):
 # /accounts/<guid>  (GET, PUT, PATCH, DELETE)
 
 
-@csrf_exempt
-@require_http_methods(["PUT", "PATCH", "DELETE"])
-def account_detail(request, guid):
+@extend_schema(
+    methods=["PUT"],
+    summary="Rename or change account type (Contract 3)",
+    request=UpdateAccountSerializer,
+    responses={
+        200: AccountResponseSerializer,
+        400: OpenApiResponse(description="Validation error or invalid JSON"),
+        404: OpenApiResponse(description="Account not found"),
+    },
+)
+@extend_schema(
+    methods=["PATCH"],
+    summary="Freeze or unfreeze an account (Contract 2)",
+    request=FreezeAccountSerializer,
+    responses={
+        200: AccountResponseSerializer,
+        400: OpenApiResponse(description="Validation error or invalid JSON"),
+        404: OpenApiResponse(description="Account not found"),
+    },
+)
+@extend_schema(
+    methods=["DELETE"],
+    summary="Soft-delete an account (Contract 4)",
+    responses={
+        200: OpenApiResponse(description="Account deleted"),
+        404: OpenApiResponse(description="Account not found"),
+    },
+)
+@api_view(["PUT", "PATCH", "DELETE"])
+def account_detail(request: Request, guid):
     """Single-account operations dispatched by HTTP method."""
     try:
         account = services.get_account_by_guid(guid)
@@ -185,9 +221,17 @@ def _delete_account(account):
 # /accounts/<guid>/transactions  (POST)
 
 
-@csrf_exempt
-@require_http_methods(["POST"])
-def account_transactions(request, guid):
+@extend_schema(
+    summary="Initiate a bank transaction (Contract 5)",
+    request=TransactionSerializer,
+    responses={
+        202: OpenApiResponse(description="Transaction initiated"),
+        400: OpenApiResponse(description="Validation error or invalid JSON"),
+        404: OpenApiResponse(description="Account not found"),
+    },
+)
+@api_view(["POST"])
+def account_transactions(request: Request, guid):
     """Initiate a bank transaction (Contract 5)."""
     try:
         account = services.get_account_by_guid(guid)
@@ -221,9 +265,17 @@ def account_transactions(request, guid):
 # /accounts/<guid>/exchanges  (POST)
 
 
-@csrf_exempt
-@require_http_methods(["POST"])
-def account_exchanges(request, guid):
+@extend_schema(
+    summary="Initiate a currency exchange (Contract 6)",
+    request=ExchangeSerializer,
+    responses={
+        202: OpenApiResponse(description="Exchange initiated"),
+        400: OpenApiResponse(description="Validation error or invalid JSON"),
+        404: OpenApiResponse(description="Account not found"),
+    },
+)
+@api_view(["POST"])
+def account_exchanges(request: Request, guid):
     """Initiate a currency exchange request (Contract 6)."""
     try:
         account = services.get_account_by_guid(guid)

--- a/services/service-account/requirements.txt
+++ b/services/service-account/requirements.txt
@@ -7,3 +7,4 @@ pika==1.3.2
 psycopg2-binary==2.9.9
 pylint-django==2.5.5
 PyJWT==2.8.0
+drf-spectacular==0.27.2


### PR DESCRIPTION
# Pull Request

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

Adds live Swagger UI to service-account via `drf-spectacular`.

- `/api/docs/` — Swagger UI with BearerAuth JWT support
- `/api/schema/` — raw OpenAPI 3.0 YAML download
- All 6 contracts documented with request/response schemas
- Updated README with new endpoints, auth info and Swagger links

## Related Tickets & Documents

- Related Issue #

## Added/updated tests?

- [ ] Yes, added
- [ ] Yes, updated
- [x] No, and this is why: config/infrastructure change only, no business logic affected